### PR TITLE
fixed unix file picker list building

### DIFF
--- a/YALCT/FilePicker.cs
+++ b/YALCT/FilePicker.cs
@@ -60,7 +60,7 @@ namespace YALCT
 
         private string RemoveItemPathMarkup(string item)
         {
-            return item.Replace(path, "").Replace(@"\", "");
+            return item.Replace(path, "").Replace(@"\", "").Replace(@"/", "");
         }
 
         private void SetPath(string newPath)


### PR DESCRIPTION
added a trailing `/` which prevented the path from being built.